### PR TITLE
Add `every` method

### DIFF
--- a/addon-test-support/-private/properties/collection.js
+++ b/addon-test-support/-private/properties/collection.js
@@ -29,6 +29,10 @@ class CollectionProxy {
   toArray() {
     return this._collection.toArray();
   }
+  
+  every(...args) {
+    this.map(...args).every(x => x);
+  }
 
   filter(...args) {
     return this._collection.filter(...args);


### PR DESCRIPTION
has similar semantics to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every