### PR TITLE
avoid "ember-cli-page-object.string-properties-on-definitio" deprecation

### DIFF
--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -9,7 +9,9 @@ import { findElement } from 'ember-classy-page-object/extend';
 const ToggleButtonPage = PageObject.extend({
   toggle: clickable('[data-test-toggle-button]'),
 
-  activeClass: 'is-active',
+  get activeClass() {
+    return 'is-active';
+  },
 
   get isActive() {
     return findElement(this, '[data-test-toggle-button]').classList.contains(this.activeClass);
@@ -23,10 +25,12 @@ const DoubleTogglePage = PageObject.extend({
 
   secondToggle: ToggleButtonPage.extend({
     scope: '[data-test-second-toggle]',
-    activeClass: 'is-activated'
+
+    get activeClass() {
+      return 'is-activated';
+    },
   })
 });
-
 
 module('Acceptance | simple', async function(hooks) {
   setupApplicationTest(hooks);


### PR DESCRIPTION
see http://ember-cli-page-object.js.org/docs/v1.17.x/deprecations.html#string-properties-on-definition

@mixonic I've assumed the problem described in https://github.com/san650/ember-cli-page-object/pull/534 should have been somehow appeared in here, but instead I've noticed this deprecation on CI.

From the ec-page-object standpoint, the deprecation for the plain strings on definitions is a part of a plan to enable a more fluent way to write definitions. So at some point, any plain strings should be treated as a `scope` of nested component(https://github.com/san650/ember-cli-page-object/issues/408).

Wrapping `activeClass` with a getter, allows to hide a string from the ec-page-object, and it fixes the deprecation warning.

Just in case, there is another possible direction to fix the deprecation, like:
```js
 isActive: hasClass('is-active', '[data-test-toggle-button]');
```

But seems the point of this page object is to demonstrate/test native `get` support for the `isActive`, so I went with adding another getter to the page object.

----

I did also notice some other deprecations caused by outdated usage of ember `deprecate(` utility by ec-page-object. I'll try to fix it , and publish new version this weekend.