### PR TITLE
Drop unused, deprecated shims

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.1",
-    "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",

--- a/tests/acceptance/simple-test.js
+++ b/tests/acceptance/simple-test.js
@@ -28,7 +28,7 @@ const DoubleTogglePage = PageObject.extend({
 
     get activeClass() {
       return 'is-activated';
-    },
+    }
   })
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,14 +3403,6 @@ ember-cli-preprocess-registry@^3.1.0:
     process-relative-require "^1.0.0"
     silent-error "^1.0.0"
 
-ember-cli-shims@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-shims/-/ember-cli-shims-1.1.0.tgz#0e3b8a048be865b4f81cc81d397ff1eeb13f75b6"
-  dependencies:
-    ember-cli-babel "^6.0.0-beta.7"
-    ember-cli-version-checker "^1.2.0"
-    silent-error "^1.0.1"
-
 ember-cli-sri@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz#971620934a4b9183cf7923cc03e178b83aa907fd"
@@ -3451,12 +3443,6 @@ ember-cli-uglify@^2.0.0:
   dependencies:
     broccoli-uglify-sourcemap "^2.0.0"
     lodash.defaultsdeep "^4.6.0"
-
-ember-cli-version-checker@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
-  dependencies:
-    semver "^5.3.0"
 
 ember-cli-version-checker@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Drop deprecated shims from the package.json. If tests fail for older versions of Ember, I'll re-add these in ember-try.