### PR TITLE
fix: depend on ember-auto-import alongside ember-cli-page-object

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
+    "ember-auto-import": "^2.4.0",
     "ember-cli-babel": "^7.12.0",
     "ember-cli-page-object": "~v2.0.0-beta.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-auto-import": "^2.4.0",
     "ember-cli": "~3.1.4",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-eslint": "^5.1.0",


### PR DESCRIPTION
This addon is a transitive dependency of a Ember Addon I'm using in a
private repository.

Without this change, I receive a built-time error when I use the addon
in my Ember Engine project:
`ember-classy-page-object needs to depend on ember-auto-import in order
to use ember-cli-page-object`

Including ember-auto-import in the package.json dependencies section
of this addon fixes that error in my project.
