### PR TITLE
Move ember-auto-import from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
+    "ember-auto-import": "^2.4.0",
     "ember-cli-babel": "^7.12.0",
     "ember-cli-page-object": "~v2.0.0-beta.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-auto-import": "^2.4.0",
     "ember-cli": "~3.1.4",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-eslint": "^5.1.0",


### PR DESCRIPTION
Required for versions of ember-cli-page-object `>= v2.0.0-beta.4`, because that addon was [migrated to the V2 addon format](https://github.com/san650/ember-cli-page-object/releases/tag/v2.0.0-beta.4).

I _think_ this will force all consuming apps/addons to use ember-auto-import 2.x, so maybe this warrants a 1.0 release?

Fixes #39.