### PR TITLE
Add a GitHub action to check for unowned files against CODEOWNERS

### DIFF
--- a/.github/workflows/codeowners-scan.yaml
+++ b/.github/workflows/codeowners-scan.yaml
@@ -1,0 +1,11 @@
+name: Codeowners Scan
+on:
+  pull_request
+
+jobs:
+  codeowners-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Addepar/codeowners-scan/.github/actions/codeowners-scan@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For information on this PR, please visit: 
https://addepar.atlassian.net/wiki/spaces/EN/blog/2022/10/13/11270389844/CODEOWNERS+Check+Automation+GitHub+Action

[_Created by Sourcegraph batch change `navcast/codeowners-action`._](https://addepar.sourcegraph.com/users/navcast/batch-changes/codeowners-action)