### PR TITLE
fix: remove non-existent module reexports

### DIFF
--- a/addon-test-support/extend.js
+++ b/addon-test-support/extend.js
@@ -1,7 +1,6 @@
 export {
   buildSelector,
-  fullScope,
-  getContext
+  fullScope
 } from 'ember-cli-page-object/extend';
 
 import {

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -7,7 +7,6 @@ export {
   count,
   fillable,
   hasClass,
-  is,
   isHidden,
   isPresent,
   isVisible,


### PR DESCRIPTION
This addon reexports modules from `ember-cli-page-object` that don't exist, which Embroider isn't happy about.

Fixes the warning under `embroider-optimized`:

```
WARNING in ../rewritten-packages/ember-classy-page-object.7a684b41/node_modules/ember-classy-page-object/extend.js 1:0-84
export 'getContext' (reexported as 'getContext') was not found in 'ember-cli-page-object/extend' (possible exports: buildSelector, findElement, findElementWithAssert, findMany, findOne, fullScope)
 @ ../rewritten-packages/ember-table.27409443/node_modules/ember-table/test-support/pages/ember-table.js 2:0-62 59:11-22 67:33-44 75:11-22 87:11-22 95:33-44 103:11-22 109:11-22 121:11-22 141:22-33
 @ ../rewritten-packages/ember-table.27409443/node_modules/ember-table/test-support/index.js 1:0-44 12:0-35
 @ ./tests/test-helper.ts 11:0-82 13:0-22
 @ ./assets/test.js 68:13-79 76:4-35
WARNING in ../rewritten-packages/ember-classy-page-object.7a684b41/node_modules/ember-classy-page-object/index.js 1:0-218
export 'is' (reexported as 'is') was not found in 'ember-cli-page-object' (possible exports: attribute, blurrable, buildSelector, clickOnText, clickable, collection, contains, count, create, default, fillable, findElement, findElementWithAssert, focusable, hasClass, isHidden, isPresent, isVisible, notHasClass, property, selectable, text, triggerable, value, visitable)
 @ ../rewritten-packages/ember-table.27409443/node_modules/ember-table/test-support/pages/ember-table.js 1:0-61 20:15-32 38:8-13 39:11-16 43:11-16 47:16-21 48:11-16
 @ ../rewritten-packages/ember-table.27409443/node_modules/ember-table/test-support/index.js 1:0-44 12:0-35
 @ ./tests/test-helper.ts 11:0-82 13:0-22
 @ ./assets/test.js 68:13-79 76:4-35
```

ref:
- https://github.com/san650/ember-cli-page-object/blob/v2.0.0-beta.3/addon-test-support/index.js
- https://github.com/san650/ember-cli-page-object/blob/v2.0.0-beta.3/addon-test-support/extend/index.js