### PR TITLE
Remove missing re-export of "is" from ember-cli-page-object

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -7,7 +7,6 @@ export {
   count,
   fillable,
   hasClass,
-  is,
   isHidden,
   isPresent,
   isVisible,
@@ -16,13 +15,11 @@ export {
   text,
   triggerable,
   value,
-  visitable
-} from 'ember-cli-page-object';
+  visitable,
+} from "ember-cli-page-object";
 
-export {
-  alias
-} from 'ember-cli-page-object/macros';
+export { alias } from "ember-cli-page-object/macros";
 
-export { collection } from './-private/properties/collection';
+export { collection } from "./-private/properties/collection";
 
-export { default } from './-private/page-object';
+export { default } from "./-private/page-object";


### PR DESCRIPTION
The `is` helper was removed from ember-cli-page-object in the 2.x series, and its [deprecations guide](https://ember-cli-page-object.js.org/docs/v1.17.x/deprecations) points this out:

> we no longer recommend to use is property, and plan to remove it in v2 of page objects.

![image](https://github.com/user-attachments/assets/4fb750c5-3130-4d65-8509-435dc025a181)


I noticed that this was an invalid re-export when running a a local embroider build of ember-table (which depends on this addon).
