### PR TITLE
Upgrade deprecated github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node 14
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
       - name: Node Modules Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ci-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install Dependencies
@@ -50,17 +50,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node 14
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 14.x
 
       - name: Node Modules Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ci-yarn-${{ matrix.ember-version }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install


### PR DESCRIPTION
This PR upgrades several old or deprecated github actions

  * actions/cache versions to latest: v4. versions below v4 will be removed (unusable) soon, see: https://github.com/actions/toolkit/discussions/1890
  * actions/setup-node to latest: v4
  * actions/checkout to latest: v4

All the upgrades should be back-compatible.