### PR TITLE
CI: Add embroider-safe, -optimized scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     strategy:
       matrix:
         ember-version: [
+          embroider-safe,
+          embroider-optimized,
           ember-lts-3.28,
           ember-lts-4.4,
           ember-lts-4.8,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = function() {
   return Promise.all([
@@ -10,6 +11,8 @@ module.exports = function() {
     return {
       useYarn: true,
       scenarios: [
+        embroiderSafe(),
+        embroiderOptimized(),
         {
           name: 'ember-lts-3.28',
           npm: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,5 +15,6 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  const { maybeEmbroider } = require('@embroider/test-setup');
+  return maybeEmbroider(app);
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.2.0",
     "@ember/test-helpers": "^2.9.4",
+    "@embroider/test-setup": "^4.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.28.6",
     "ember-cli-dependency-checker": "^3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,14 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
+"@embroider/test-setup@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-4.0.0.tgz#080dd40314a53cc6f6fcffed41cd24ee0cb48b3d"
+  integrity sha512-1S3Ebk0CEh3XDqD93AWSwQZBCk+oGv03gtkaGgdgyXGIR7jrVyDgEnEuslN/hJ0cuU8TqhiXrzHMw7bJwIGhWw==
+  dependencies:
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+
 "@embroider/util@^1.9.0":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.13.2.tgz#446f5861ca387b523cf033640265ae820cc1d7aa"


### PR DESCRIPTION
Builds on #52. This is ready for review, but #52 should be reviewed/merged first.
The relative diff is very modest: https://github.com/Addepar/ember-classy-page-object/compare/bantic/webcore-3122-fix-ci-ember-4...bantic/webcore-3124-embroider

This follows https://github.com/embroider-build/embroider/blob/5fd49b50dd82bf7ceb6adeefa12efc2b85f92cd2/ADDON-AUTHOR-GUIDE.md#support-level-embroider-safe to add embroider scenarios to CI.