### PR TITLE
fix: remove nonexistant module reexports

### DIFF
--- a/addon-test-support/extend.js
+++ b/addon-test-support/extend.js
@@ -1,7 +1,6 @@
 export {
   buildSelector,
-  fullScope,
-  getContext
+  fullScope
 } from 'ember-cli-page-object/extend';
 
 import {

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -7,7 +7,6 @@ export {
   count,
   fillable,
   hasClass,
-  is,
   isHidden,
   isPresent,
   isVisible,


### PR DESCRIPTION
Cherry-picked the commit from #45 in order to run it on current default branch, now that CI has been fixed via #53, see: https://github.com/Addepar/ember-classy-page-object/pull/45#issuecomment-2568970850

Also opened https://github.com/Addepar/ember-classy-page-object/pull/56 which includes this change as well as the changes in #54 , to confirm that this change passes when run against the embroider scenarios.